### PR TITLE
fix a build issue on linux

### DIFF
--- a/libusb/usb.h
+++ b/libusb/usb.h
@@ -46,6 +46,11 @@ typedef unsigned __int32  uint32_t;
 #include <stdint.h>
 #endif
 
+/* On linux PATH_MAX is defined in linux/limits.h. */
+#if defined(__linux__)
+#include <linux/limits.h>
+#endif
+
 /*
  * USB spec information
  *


### PR DESCRIPTION
On linux PATH_MAX is defined in linux/limits.h. If we include usb.h
without previously having indirectly included it, the build fails.

Signed-off-by: Bartosz Golaszewski <brgl@bgdev.pl>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libusb-compat/0002-fix-a-build-issue-on-linux.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>