### PR TITLE
Fix empty else in configure script

### DIFF
--- a/m4/au_check_lib_soname.m4
+++ b/m4/au_check_lib_soname.m4
@@ -32,8 +32,7 @@ libusb_close((void*)0);
             [AS_VAR_SET([ac_Lib_SONAME], [unknown])])
           AS_IF([test x"$ac_Lib_SONAME" != x"unknown" ], [
             AS_VAR_SET([$1][_SONAME], ["$ac_Lib_SONAME"])
-            $4], [
-            $5])], [
+            $4])], [
           AS_VAR_SET([ac_Lib_SONAME], [unknown])
           $5])], [
         AS_VAR_SET([ac_Lib_SONAME], ["$[$1][_SONAME]"])


### PR DESCRIPTION
Hello!

After running bootstrap.sh on my MSYS2 installation, the configure script couldn't be run due to a syntax error with an empty else.
I tracked it down to the $5 which I removed in this commit. With it removed, it builds for me successfully.
Don't know how this was supposed to be used. If it's in fact needed please tell me how to fix it and remove this pull request.