### PR TITLE
Fix testlibusb -Wformat-truncation warning and bump actions/checkout

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job
       # can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: setup prerequisites
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job
       # can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: setup prerequisites
         shell: bash

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -8,7 +8,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64

--- a/examples/testlibusb.c
+++ b/examples/testlibusb.c
@@ -62,7 +62,7 @@ static void print_configuration(struct usb_config_descriptor *config)
 static int print_device(struct usb_device *dev, int level)
 {
   usb_dev_handle *udev;
-  char description[256];
+  char description[512];
   char string[256];
   int ret, i;
 


### PR DESCRIPTION
Two unrelated warnings observed across the Linux and MSYS2 jobs, fixed in
separate commits.

## examples: enlarge testlibusb description buffer

GCC (both Linux and mingw-w64) emits:

```
testlibusb.c:74: warning: ' - ' directive output may be truncated
    writing 3 bytes into a region of size between 1 and 256
    [-Wformat-truncation=]
```

`description` and `string` were both 256 bytes, so a maximally-long
manufacturer string left no room for the literal `" - "`. The same
buffer then has to absorb the product string appended via the second
`snprintf`, so 256 was already too small to fit
`"manufacturer - product"` anyway. Bumping `description` to 512 bytes
silences the warning and gives the assembled line enough room. The
bounded `snprintf` calls keep the buffer safe regardless.

## ci: bump actions/checkout from v2 to v6

`actions/checkout@v2` runs on Node 12 and emits a deprecation warning
on every job. v6 is the current major release. The action is invoked
with no inputs, so this is a straight version bump. `msys2/setup-msys2`
is left at `v2` because that is still its current major.

## Test plan

- [x] `./autogen.sh --enable-examples-build && make -j4` on Linux —
      no warnings (was: one `-Wformat-truncation` warning on
      `testlibusb.c:74`).
- [x] CI: linux, macOS, MSYS2 jobs run cleanly without `actions/checkout`
      deprecation warnings, and `testlibusb` builds without
      `-Wformat-truncation`.

Fixes: #32